### PR TITLE
Add option for setting the value when constructing a model

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,6 +106,8 @@ function buildModel(name, schema, override) {
 
         var model;
 
+        // TODO: Make sure that the model name is a valid Function name
+
         // We're using eval here to make it easier to debug.
         /* jslint evil:true */
         eval('model = function ' + name + '() { Model.apply(this, arguments); }');

--- a/src/model.js
+++ b/src/model.js
@@ -43,6 +43,14 @@ function Model(options) {
             this._name = this._fields.id.get();
         }
     }
+
+    // Set a value if one was supplied,
+    //
+    // To make things cleaner we might want to refactor how options/values are
+    // supplied through the constructor.
+    if (options && options.value) {
+        this.set(options.value);
+    }
 }
 
 module.exports = Model;


### PR DESCRIPTION
Implemented a way to provide data while constructing the document. It's not currently as clean as I'd like, but the `Model` constructor already takes an object to provide options, such as the document `name` (this is basically the key, todo: update this naming convention). So, to get this in, I made the value another option:

```
var model = Model({ value: data });
```
